### PR TITLE
Wrap the event stream generator into a function in order to run the initialization code immediately

### DIFF
--- a/icinga2apic/events.py
+++ b/icinga2apic/events.py
@@ -82,5 +82,9 @@ class Events(Base):
             payload,
             stream=True
         )
-        for event in self._get_message_from_stream(stream):
-            yield event
+
+        def gen():
+            for event in self._get_message_from_stream(stream):
+                yield event
+
+        return gen()


### PR DESCRIPTION
Hi! It seems logical to execute the POST request immediately, when `client.events.subscribe()` is called instead of postpone it in the generator object. The current version behaves like this:

1. `stream = client.events.subscribe(...)` **_(nothing happens!)_**
2. `for e in stream: ...` _(it fires the request and iterate over the result)_

With  the proposed version it is possible to:

1. `stream = client.events.subscribe(...)` _(connect, send the request, get `200 OK`...)_
2. `for e in stream: ...` _(process the events in a loop...)_

And it's possible to repeat the step 1 if it fails due to a connection error, etc.