### PR TITLE
feat: allow to pass author to remove_downtime

### DIFF
--- a/icinga2apic/actions.py
+++ b/icinga2apic/actions.py
@@ -538,7 +538,8 @@ class Actions(Base):
                         object_type,
                         name=None,
                         filters=None,
-                        filter_vars=None):
+                        filter_vars=None,
+                        author=None):
         '''
         Remove the downtime using its name or filters.
 
@@ -558,6 +559,8 @@ class Actions(Base):
         :type filters: string
         :param filter_vars: variables used in the filters expression
         :type filter_vars: dict
+        :param author: name of the author
+        :type author: string
         :returns: the response as json
         :rtype: dictionary
         '''
@@ -576,6 +579,8 @@ class Actions(Base):
             payload['filter'] = filters
         if filter_vars:
             payload['filter_vars'] = filter_vars
+        if author:
+            payload['author'] = author
 
         return self._request('POST', url, payload)
 


### PR DESCRIPTION
Solves #8

Compliant to the REST API (https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#remove-downtime) of Icinga 2, someone may pass the name of the removal requestor to the action remove-downtime. This PR will adds this feature.

Signed-off-by: Fiehe Christoph  <c.fiehe@eurodata.de>
