### PR TITLE
feat: improved error handling and provide more specific error classes 

### DIFF
--- a/icinga2apic/base.py
+++ b/icinga2apic/base.py
@@ -110,33 +110,36 @@ class Base(object):
         if self.manager.ca_certificate:
             request_args['verify'] = self.manager.ca_certificate
         else:
-            request_args['verify'] = False
+            if self.manager.validate_certs:
+                request_args['verify'] = True
+            else:
+                request_args['verify'] = False
         if stream:
             request_args['stream'] = True
+        if self.manager.timeout:
+            request_args['timeout'] = self.manager.timeout
 
-        # do the request
-        response = session.post(**request_args)
-
-        if not stream:
-            session.close()
-        # # for debugging
-        # from pprint import pprint
-        # pprint(request_url)
-        # pprint(payload)
-        # pprint(response)
+        try:
+            # do the request
+            response = session.post(**request_args)
+        except requests.exceptions.ProxyError as e:
+            raise Icinga2ApiProxyException(method, request_url)
+        except requests.exceptions.ConnectionError as e:
+            raise Icinga2ApiClientException(method, request_url, e)
+        except requests.exceptions.Timeout as e:
+            raise Icinga2ApiTimeoutException(method, request_url, self.manager.timeout)
+        finally:
+            if not stream:
+                session.close()
 
         if not 200 <= response.status_code <= 299:
-            raise Icinga2ApiRequestException(
-                'Request "{}" failed with status {}: {}'.format(
-                    response.url,
-                    response.status_code,
-                    response.text,
-                ),response.json())
+            raise Icinga2ApiHttpException(method, request_url, response.status_code, response)
 
         if stream:
             return response
         else:
             return response.json()
+
 
     @staticmethod
     def _get_message_from_stream(stream):

--- a/icinga2apic/client.py
+++ b/icinga2apic/client.py
@@ -48,35 +48,32 @@ class Client(object):
     Icinga 2 Client class
     '''
 
-    def __init__(self,
-                 url=None,
-                 username=None,
-                 password=None,
-                 timeout=None,
-                 certificate=None,
-                 key=None,
-                 ca_certificate=None,
-                 config_file=None):
+    def __init__(
+        self,
+        url=None,
+        username=None,
+        password=None,
+        timeout=None,
+        validate_certs=False,
+        certificate=None,
+        key=None,
+        ca_certificate=None,
+        config_file=None,
+    ):
         '''
         initialize object
         '''
         config_from_file = ClientConfigFile(config_file)
         if config_file:
             config_from_file.parse()
-        self.url = url or \
-            config_from_file.url
-        self.username = username or \
-            config_from_file.username
-        self.password = password or \
-            config_from_file.password
-        self.timeout = timeout or \
-            config_from_file.timeout
-        self.certificate = certificate or \
-            config_from_file.certificate
-        self.key = key or \
-            config_from_file.key
-        self.ca_certificate = ca_certificate or \
-            config_from_file.ca_certificate
+        self.url = url or config_from_file.url
+        self.username = username or config_from_file.username
+        self.password = password or config_from_file.password
+        self.timeout = timeout or config_from_file.timeout
+        self.validate_certs = validate_certs or config_from_file.validate_certs
+        self.certificate = certificate or config_from_file.certificate
+        self.key = key or config_from_file.key
+        self.ca_certificate = ca_certificate or config_from_file.ca_certificate
         self.objects = Objects(self)
         self.actions = Actions(self)
         self.events = Events(self)
@@ -87,5 +84,5 @@ class Client(object):
             raise Icinga2ApiException('No "url" defined.')
         if not self.username and not self.password and not self.certificate:
             raise Icinga2ApiException(
-                'Neither username/password nor certificate defined.'
+                "Neither username/password nor certificate defined."
             )

--- a/icinga2apic/configfile.py
+++ b/icinga2apic/configfile.py
@@ -57,6 +57,7 @@ class ClientConfigFile(object):
         self.key = None
         self.ca_certificate = None
         self.timeout = None
+        self.validate_certs = None
         if self.file_name:
             self.check_access()
 
@@ -160,6 +161,15 @@ class ClientConfigFile(object):
             self.timeout = str(cfg.get(
                 self.section,
                 'timeout'
+            )).strip()
+        except configparser.NoOptionError:
+            pass
+
+        # [api]/validate_certs
+        try:
+            self.validate_certs = str(cfg.get(
+                self.section,
+                'validate_certs'
             )).strip()
         except configparser.NoOptionError:
             pass

--- a/icinga2apic/exceptions.py
+++ b/icinga2apic/exceptions.py
@@ -26,38 +26,80 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Icinga 2 API client exceptions
 '''
 
+
 class Icinga2ApiException(Exception):
     '''
-    Icinga 2 API exception class
+    Icinga 2 API base exception.
     '''
 
-    def __init__(self, error):
-        super(Icinga2ApiException, self).__init__(error)
-        self.error = error
-
-    def __str__(self):
-        return str(self.error)
 
 class Icinga2ApiRequestException(Icinga2ApiException):
     '''
+    Icinga 2 API request exception.
+    '''
+
+    def __init__(self, method, url, error):
+        super(Icinga2ApiRequestException, self).__init__(error)
+        self.method = method
+        self.url = url
+
+
+class Icinga2ApiProxyException(Icinga2ApiRequestException):
+    '''
+    Icinga 2 API HTTP connection to proxy server failed.
+    '''
+
+    def __init__(self, method, url):
+        super(Icinga2ApiProxyException, self).__init__(
+            method,
+            url,
+            "Request {} {} failed: Unable to connect to proxy.".format(method, url),
+        )
+
+
+class Icinga2ApiClientException(Icinga2ApiRequestException):
+    '''
+    Icinga 2 API HTTP connection error.
+    '''
+
+    def __init__(self, method, url, exception):
+        super(Icinga2ApiClientException, self).__init__(
+            method, url, "Request {} {} failed: {}".format(method, url, exception)
+        )
+
+
+class Icinga2ApiHttpException(Icinga2ApiRequestException):
+    '''
     Icinga 2 API Request exception class
     '''
-    response = {}
 
-    def __init__(self, error, response):
-        super(Icinga2ApiRequestException, self).__init__(error)
-        self.response = response
+    def __init__(self, method, url, status_code, response):
+        super(Icinga2ApiHttpException, self).__init__(
+            method,
+            url,
+            "Request {} {} failed with status code {}: {}".format(
+                method, url, status_code, response.text
+            ),
+        )
+        self.status_code = status_code
+        self.response = response.json()
 
 
+class Icinga2ApiTimeoutException(Icinga2ApiRequestException):
+    '''
+    Icinga 2 API request timeout.
+    '''
 
-class Icinga2ApiConfigFileException(Exception):
+    def __init__(self, method, url, timeout):
+        super(Icinga2ApiTimeoutException, self).__init__(
+            method,
+            url,
+            "Request {} {} timed out after {} seconds.".format(method, url, timeout),
+        )
+        self.timeout = timeout
+
+
+class Icinga2ApiConfigFileException(Icinga2ApiException):
     '''
     Icinga 2 API config file exception class
     '''
-
-    def __init__(self, error):
-        super(Icinga2ApiConfigFileException, self).__init__(error)
-        self.error = error
-
-    def __str__(self):
-        return str(self.error)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 setup(
    version=__version__,


### PR DESCRIPTION
Solves #10

Currently, exceptions coming from the `requests` module are directly passed to the user. It would be nice to improve encapsulation and keep the implementation details private.

An object of the class `Icinga2ApiRequestException` contains only little information about what actually caused the request to fail. This PR adds some more specific exception classes, which contain more information about the error context. This information helps a user to decide how to react to those specific error situations.

This PR also fixes the timeout handling, because the timeout value was ignored beforehand. Even when it was given, the request was always done without any time limits. This PR also adds a new boolean setting `validate_certs`, which allows a user to decide if the server certificate should be validated against the installed CA certificates. The default is `false`, in order to be backward compatible with older versions of this library.

Signed-off-by: Fiehe Christoph  <c.fiehe@eurodata.de>
